### PR TITLE
hotfix/ios safari에서 pinch zoom 시 UI 전체가 연관되는 현상을 수정

### DIFF
--- a/src/components/KakaoMap.css
+++ b/src/components/KakaoMap.css
@@ -9,3 +9,8 @@
   text-align: center;
   box-shadow: 0 1px 3px rgba(0,0,0,0.2);
 }
+
+/* 브라우저의 핀치는 제한, 카카오맵은 별도 JS로 동작하여 영향을 주지 않는다 함*/
+.kakaomap-container{
+  touch-action: pan-x pan-y;
+}

--- a/src/components/KakaoMap.jsx
+++ b/src/components/KakaoMap.jsx
@@ -113,7 +113,7 @@ const KakaoMap = ({ center, storeData }) => {
         };
     }, [center, storeData, KAKAO_JS_KEY]);
 
-    return <div ref={mapRef} style={{ width: "100%", height: "597px" }} />;
+    return <div ref={mapRef} className="kakaomap-container" style={{ width: "100%", height: "597px" }} />;
 };
 
 export default KakaoMap;


### PR DESCRIPTION
- IOS safari 환경에서 카카오맵을 pinch zoom out 시 지도 뿐만 아니라 UI 전체가 축소되는 현상이 발생
- touch-action css 속성을 조정하여 기본 pinch 시엔 수직 수평 움직임만 허용함
- 카카오맵은 별도 JS 로직으로 동작하여 축소 확대같은 레벨 조정에 이번 css 조정의 영향을 받지 않음
- 테스트 후 이상 발견 시 수정